### PR TITLE
fix compute_metrics in colab notebook

### DIFF
--- a/whisper-fine-tuning-event/fine_tune_whisper_streaming_colab.ipynb
+++ b/whisper-fine-tuning-event/fine_tune_whisper_streaming_colab.ipynb
@@ -806,7 +806,10 @@
     "        label_str = [normalizer(label) for label in label_str]\n",
     "        # filtering step to only evaluate the samples that correspond to non-zero references:\n",
     "        pred_str = [pred_str[i] for i in range(len(pred_str)) if len(label_str[i]) > 0]\n",
-    "        label_str = [label_str[i] for i in range(len(label_str)) if len(label_str[i]) > 0]"
+    "        label_str = [label_str[i] for i in range(len(label_str)) if len(label_str[i]) > 0]\n",
+    "    \n",
+    "    wer = 100 * metric.compute(predictions=pred_str, references=label_str)\n",
+    "    return {\"wer\":wer}"
    ]
   },
   {
@@ -1178,7 +1181,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.9"
+   "version": "3.8.15"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
`compute_metrics` function in colab notebook is incomplete. This causes errors at evaluation (see the [issue reported on discord](https://discord.com/channels/879548962464493619/914890191125217290/1051533159977721876)).

Fixed by making`compute_metrics` the same as in the other notebooks.