### PR TITLE
[WFTE] Fix DS scheduler

### DIFF
--- a/whisper-fine-tuning-event/ds_config.json
+++ b/whisper-fine-tuning-event/ds_config.json
@@ -18,14 +18,16 @@
         }
     },
 
-    "scheduler": {
-        "type": "WarmupLR",
-        "params": {
-            "warmup_min_lr": "auto",
-            "warmup_max_lr": "auto",
-            "warmup_num_steps": "auto"
-        }
-    },
+   "scheduler": {
+         "type": "WarmupDecayLR",
+         "params": {
+             "last_batch_iteration": -1,
+             "total_num_steps": "auto",
+             "warmup_min_lr": "auto",
+             "warmup_max_lr": "auto",
+             "warmup_num_steps": "auto"
+         }
+     },
 
     "zero_optimization": {
         "stage": 2,


### PR DESCRIPTION
As pointed out by @anuragshas, the DS config uses a LR scheduler with ramp warm-up then constant value (`WarmupLR`). This PR updates the DS config to use ramp warm-up then linear decay (`WarmupDecayLR`), in conjunction with the default HF Trainer behaviour.