### PR TITLE
Change mention of "Whisper" to "Stable Diffusion"

### DIFF
--- a/keras-dreambooth-sprint/compute-with-lambda.md
+++ b/keras-dreambooth-sprint/compute-with-lambda.md
@@ -1,7 +1,7 @@
 ## Launch a Lambda Cloud GPU
 Where possible, we encourage you to fine-tune Dreambooth on a local GPU machine. This will mean a faster set-up and more familiarity with your device. 
 
-The training scripts can also be run as a notebook through Google Colab. We recommend you train on Google Colab if you have a "Colab Pro" or "Pro+" subscription. This is to ensure that you receive a sufficiently powerful GPU on your Colab for fine-tuning Whisper. 
+The training scripts can also be run as a notebook through Google Colab. We recommend you train on Google Colab if you have a "Colab Pro" or "Pro+" subscription. This is to ensure that you receive a sufficiently powerful GPU on your Colab for fine-tuning Stable Diffusion. 
 
 If you do not have access to a local GPU or Colab Pro/Pro+, we'll endeavour to provide you with a cloud GPU instance.
 We've partnered up with Lambda to provide cloud compute for this event. They'll be providing the NVIDIA A10 24 GB GPUs. The Lambda API makes it easy to spin-up and launch a GPU instance. In this section, we'll go through the steps for spinning up an instance one-by-one.


### PR DESCRIPTION
Fixed a one word mistake: the event is about finetuning Stable Diffusion, not Whisper