### PR TITLE
Install pinned jax, flax in requirements

### DIFF
--- a/jax-controlnet-sprint/README.md
+++ b/jax-controlnet-sprint/README.md
@@ -275,10 +275,18 @@ We can activate the environment by running:
 source ~/<your-venv-name>/bin/activate
 ```
 
-Now, we can install JAX `0.4.5`:
+Then install Diffusers and the library's training dependencies:
 
 ```bash
-pip install "jax[tpu]==0.4.5" -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
+pip install git+https://github.com/huggingface/diffusers.git
+```
+
+Then clone this repository and install JAX, Flax and the other dependencies:
+
+```bash
+git clone https://github.com/huggingface/community-events
+cd community-events/jax-controlnet-sprint/training_scripts
+pip install -U -r requirements_flax.txt
 ```
 
 To verify that JAX was correctly installed, you can run the following command:
@@ -289,20 +297,6 @@ jax.device_count()
 ```
 
 This should display the number of TPU cores, which should be 4 on a TPUv4-8 VM. If Python is not able to detect the TPU device, please take a look at [this section](#troubleshoot-your-tpu-vm) for solutions.
-
-Then install Diffusers and the library's training dependencies:
-
-```bash
-pip install git+https://github.com/huggingface/diffusers.git
-```
-
-Then clone this repository and install the other dependencies:
-
-```bash
-git clone https://github.com/huggingface/community-events
-cd community-events/jax-controlnet-sprint/training_scripts
-pip install -U -r requirements_flax.txt
-```
 
 If you want to use Weights and Biases logging, you should also install `wandb` now:
 

--- a/jax-controlnet-sprint/training_scripts/requirements_flax.txt
+++ b/jax-controlnet-sprint/training_scripts/requirements_flax.txt
@@ -7,8 +7,9 @@ datasets
 flax
 optax
 orbax
-torch
-torchvision
 ftfy
 tensorboard
 Jinja2
+--extra-index-url https://download.pytorch.org/whl/cpu
+torch
+torchvision

--- a/jax-controlnet-sprint/training_scripts/requirements_flax.txt
+++ b/jax-controlnet-sprint/training_scripts/requirements_flax.txt
@@ -1,9 +1,12 @@
-transformers>=4.25.1
-chex==0.1.6
-datasets
+-f https://storage.googleapis.com/jax-releases/libtpu_releases.html
+jax[tpu]==0.4.5
 flax==0.6.7
+transformers
+chex
+datasets
+flax
 optax
-orbax==0.1.4
+orbax
 torch
 torchvision
 ftfy


### PR DESCRIPTION
So that compatible versions of other dependencies are automatically chosen.