### PR TITLE
Adds a default use_auth_token=None to LightweightGAN._from_pretrained…

### DIFF
--- a/huggan/pytorch/lightweight_gan/lightweight_gan.py
+++ b/huggan/pytorch/lightweight_gan/lightweight_gan.py
@@ -860,7 +860,7 @@ class LightweightGAN(nn.Module, HugGANModelHubMixin):
             proxies,
             resume_download,
             local_files_only,
-            use_auth_token,
+            use_auth_token=None,
             map_location="cpu",
             strict=False,
             **model_kwargs,


### PR DESCRIPTION
… to address https://github.com/huggingface/community-events/issues/194